### PR TITLE
(partly) thread-safe implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all test clean
 
-all: cpptest ctest libmonoalloc.so
+all: cpptest ctest libmonoalloc.so threadtest
 
 ifneq ($(D),)
 EXTRAFLAGS:=-DDEBUG -g
@@ -17,11 +17,16 @@ ctest: test.c libmonoalloc.so
 	gcc -Wall $(EXTRAFLAGS) $^ -o $@
 	gcc -Wall $(EXTRAFLAGS) $< -o $@-glibc
 
-test: ctest cpptest
+threadtest: threadtest.cpp monoalloc.c
+	g++ -Wall -DTHREADS $(EXTRAFLAGS) $^ -lpthread -o $@
+
+
+test: ctest cpptest threadtest
 	LD_LIBRARY_PATH=. ./ctest -------------------------------
 	./ctest-glibc -------------------------------------------
 	LD_LIBRARY_PATH=. ./cpptest -----------------------------
 	./cpptest-glibc -----------------------------------------
+	./threadtest > threadtest.out
 
 clean:
-	rm -f cpptest ctest libmonoalloc.so cpptest-glibc ctest-glibc
+	rm -f cpptest ctest libmonoalloc.so cpptest-glibc ctest-glibc threadtest threadtest.out

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ On the other hand, you'll probably notice that `free()` is a no-op, and `realloc
 will get you a new chunk, so applications using these two often might need more memory than
 when using other allocators.
 # caveats
-not thread-safe. probably broken. for educational purposes only. NO WARRANTY. 'AS-IS'.
+probably not thread-safe. probably broken. for educational purposes only. NO WARRANTY. 'AS-IS'.
 assumes 16 bytes alignment will be enough for anybody, and that `sbrk()` only returns
 aligned pointers.
 # how to use
@@ -25,6 +25,8 @@ aligned pointers.
 - have fun.
 - to see debug output, define `DEBUG` - see `Makefile`. this will print tracing information
   for every `*alloc` call except the ones that are happening inside the tracing `printf`s.
+- to make thread-safe in a pthread-based thread implementation, define `THREADS` and link against
+  libpthread; code will then use a pthread mutex to ensure consistency of global data.
 - see source for details.
 # recommended reading
 the competition: https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c;hb=HEAD

--- a/monoalloc.c
+++ b/monoalloc.c
@@ -20,6 +20,7 @@ extern "C" {
 #ifdef DEBUG
 #include <stdio.h>
 static int indebug;
+static unsigned long long counter;
 #endif
 #ifdef THREADS
 #include <pthread.h>
@@ -61,12 +62,13 @@ void *malloc(size_t size) {
 	next = (char *)next + size;
 	currsize += size;
 #ifdef DEBUG
+	counter++;
 	if (!indebug) {
 		void * ntmp = next;
 		/* printf() would call malloc(), resulting in endless recursion... */
 		indebug = 1;
 		MUTEX_UNLOCK();
-		printf("trace: malloc'd %zd bytes, next %p, return %p\n", size, ntmp, tmp);
+		printf("trace: malloc'd %zd bytes, next %p, return %p (%llu)\n", size, ntmp, tmp, counter);
 		MUTEX_LOCK();
 		indebug = 0;
 	}

--- a/monoalloc.c
+++ b/monoalloc.c
@@ -62,9 +62,12 @@ void *malloc(size_t size) {
 	currsize += size;
 #ifdef DEBUG
 	if (!indebug) {
+		void * ntmp = next;
 		/* printf() would call malloc(), resulting in endless recursion... */
 		indebug = 1;
-		printf("trace: malloc'd %zd bytes, next %p, return %p\n", size, next, tmp);
+		MUTEX_UNLOCK();
+		printf("trace: malloc'd %zd bytes, next %p, return %p\n", size, ntmp, tmp);
+		MUTEX_LOCK();
 		indebug = 0;
 	}
 #endif

--- a/threadtest.cpp
+++ b/threadtest.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <thread>
+#include <vector>
+
+class ThreadtestClass  {
+  public:
+    void operator()() const {
+      for (int i=0; i < 10000; i++) {
+	std::vector<char> v(1, 42);
+      }
+      std::cout << "did some allocations." << '\n';
+    }
+};
+
+int main() {
+  ThreadtestClass ct;
+  std::cout << "starting threads..." << '\n';
+  std::thread t1(ct);
+  std::thread t2(ct);
+  std::thread t3(ct);
+  t1.join();
+  t2.join();
+  t3.join();
+}


### PR DESCRIPTION
...by using a mutex that guards global data. only works on pthread implementation with static initialization. may produce deadlocks if debugging output is enabled.